### PR TITLE
Change keccak256 to sha3 in corebc-core crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Crates to modify
 - [ ] corebc-core
   - [x] ICAN Addresses
   - [ ] ED448
-  - [ ] Hashing Function
+  - [x] Hashing Function
 - [ ] ethers-contract
 - [ ] ethers-etherscan
 - [ ] ethers-middleware

--- a/corebc-core/Cargo.toml
+++ b/corebc-core/Cargo.toml
@@ -34,8 +34,9 @@ arrayvec = { version = "0.7", default-features = false }
 elliptic-curve.workspace = true
 generic-array.workspace = true
 k256 = { workspace = true, features = ["ecdsa", "std"] }
-tiny-keccak.workspace = true
+# tiny-keccak.workspace = true
 rand.workspace = true
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 
 # misc
 chrono = { version = "0.4", default-features = false }

--- a/corebc-core/src/types/filter.rs
+++ b/corebc-core/src/types/filter.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::ethereum_types::BloomInput,
     types::{Address, BlockNumber, Bloom, Log, /* H160, */ H176, H256, U256, U64},
-    utils::keccak256,
+    utils::sha3,
 };
 use serde::{
     de::{DeserializeOwned, MapAccess, Visitor},
@@ -257,15 +257,14 @@ impl Filter {
     /// Given the event signature in string form, it hashes it and adds it to the topics to monitor
     #[must_use]
     pub fn event(self, event_name: &str) -> Self {
-        let hash = H256::from(keccak256(event_name.as_bytes()));
+        let hash = H256::from(sha3(event_name.as_bytes()));
         self.topic0(hash)
     }
 
     /// Hashes all event signatures and sets them as array to topic0
     #[must_use]
     pub fn events(self, events: impl IntoIterator<Item = impl AsRef<[u8]>>) -> Self {
-        let events =
-            events.into_iter().map(|e| H256::from(keccak256(e.as_ref()))).collect::<Vec<_>>();
+        let events = events.into_iter().map(|e| H256::from(sha3(e.as_ref()))).collect::<Vec<_>>();
         self.topic0(events)
     }
 
@@ -927,7 +926,7 @@ mod tests {
         });
 
         let event = "ValueChanged(address,string,string)";
-        let t0 = H256::from(keccak256(event.as_bytes()));
+        let t0 = H256::from(sha3(event.as_bytes()));
         let addr: Address = "0000f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
         let filter = Filter::new();
 

--- a/corebc-core/src/types/signature.rs
+++ b/corebc-core/src/types/signature.rs
@@ -1,9 +1,10 @@
 // Code adapted from: https://github.com/tomusdrw/rust-web3/blob/master/src/api/accounts.rs
 use crate::{
     types::{Address, H256, U256},
-    utils::hash_message,
+    utils::{hash_message, to_ican, NetworkType},
 };
 use elliptic_curve::{consts::U32, sec1::ToEncodedPoint};
+use ethabi::ethereum_types::H160;
 use generic_array::GenericArray;
 use k256::{
     ecdsa::{
@@ -126,8 +127,13 @@ impl Signature {
         let public_key = public_key.to_encoded_point(/* compress = */ false);
         let public_key = public_key.as_bytes();
         debug_assert_eq!(public_key[0], 0x04);
-        let hash = crate::utils::keccak256(&public_key[1..]);
-        Ok(Address::from_slice(&hash[12..]))
+        let hash = crate::utils::sha3(&public_key[1..]);
+
+        let mut bytes = [0u8; 20];
+        bytes.copy_from_slice(&hash[12..]);
+        let addr = H160::from(bytes);
+        // CORETODO: Change the networktype logic
+        Ok(to_ican(&addr, &NetworkType::Mainnet))
     }
 
     /// Retrieves the recovery signature.

--- a/corebc-core/src/types/transaction/eip2718.rs
+++ b/corebc-core/src/types/transaction/eip2718.rs
@@ -7,7 +7,7 @@ use crate::{
     types::{
         Address, Bytes, NameOrAddress, Signature, Transaction, TransactionRequest, H256, U256, U64,
     },
-    utils::keccak256,
+    utils::sha3,
 };
 use rlp::Decodable;
 use serde::{Deserialize, Serialize};
@@ -300,7 +300,7 @@ impl TypedTransaction {
     /// Hashes the transaction's data. Does not double-RLP encode
     pub fn sighash(&self) -> H256 {
         let encoded = self.rlp();
-        keccak256(encoded).into()
+        sha3(encoded).into()
     }
 
     /// Max cost of the transaction
@@ -315,7 +315,7 @@ impl TypedTransaction {
 
     /// Hashes the transaction's data with the included signature.
     pub fn hash(&self, signature: &Signature) -> H256 {
-        keccak256(self.rlp_signed(signature).as_ref()).into()
+        sha3(self.rlp_signed(signature).as_ref()).into()
     }
 
     /// Decodes a signed TypedTransaction from a rlp encoded byte stream

--- a/corebc-core/src/types/transaction/request.rs
+++ b/corebc-core/src/types/transaction/request.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{
         Address, Bytes, NameOrAddress, Signature, SignatureError, Transaction, H256, U256, U64,
     },
-    utils::keccak256,
+    utils::sha3,
 };
 
 use rlp::{Decodable, RlpStream};
@@ -152,8 +152,8 @@ impl TransactionRequest {
     /// Hashes the transaction's data with the provided chain id
     pub fn sighash(&self) -> H256 {
         match self.chain_id {
-            Some(_) => keccak256(self.rlp().as_ref()).into(),
-            None => keccak256(self.rlp_unsigned().as_ref()).into(),
+            Some(_) => sha3(self.rlp().as_ref()).into(),
+            None => sha3(self.rlp_unsigned().as_ref()).into(),
         }
     }
 
@@ -387,7 +387,7 @@ mod tests {
             .value(0)
             .gas(0)
             .gas_price(0);
-        let expected_sighash = "e4bfdde4640da59057026fd60394de7fd0ec35f0a4c0dee270cb4dd9051dc769";
+        let expected_sighash = "ec08902c56d6df8797a282763e4871a2b69dbb210b5390e7babbf1cebe59a23d";
         let got_sighash = hex::encode(tx.sighash().as_bytes());
         assert_eq!(expected_sighash, got_sighash);
     }
@@ -467,11 +467,10 @@ mod tests {
             .chain_id(1);
 
         let expected_rlp = hex::decode("ee098504a817c8008252089635353535353535353535353535353535353535353535880de0b6b3a764000080018080").unwrap();
-        println!("{:#?}", tx.sighash());
         assert_eq!(expected_rlp, tx.rlp().to_vec());
 
         let expected_sighash =
-            hex::decode("ff7b766295e72f47735987a6df63b0dcfef93787a0f88817caf1175433d623cf")
+            hex::decode("2e71f6c2963fa9e8ded46264e0be28402944a5f9e78d62e9de18c4df76bb2421")
                 .unwrap();
 
         assert_eq!(expected_sighash, tx.sighash().as_bytes().to_vec());

--- a/corebc-core/src/types/transaction/response.rs
+++ b/corebc-core/src/types/transaction/response.rs
@@ -8,7 +8,7 @@ use crate::{
         transaction::extract_chain_id, Address, Bloom, Bytes, Log, Signature, SignatureError, H256,
         U256, U64,
     },
-    utils::keccak256,
+    utils::sha3,
 };
 use rlp::{Decodable, DecoderError, RlpStream};
 use serde::{Deserialize, Serialize};
@@ -133,7 +133,7 @@ impl Transaction {
     }
 
     pub fn hash(&self) -> H256 {
-        keccak256(self.rlp().as_ref()).into()
+        sha3(self.rlp().as_ref()).into()
     }
 
     pub fn rlp(&self) -> Bytes {
@@ -335,7 +335,7 @@ impl Transaction {
 /// Get a Transaction directly from a rlp encoded byte stream
 impl Decodable for Transaction {
     fn decode(rlp: &rlp::Rlp) -> Result<Self, DecoderError> {
-        let mut txn = Self { hash: H256(keccak256(rlp.as_raw())), ..Default::default() };
+        let mut txn = Self { hash: H256(sha3(rlp.as_raw())), ..Default::default() };
         // we can get the type from the first value
         let mut offset = 0;
 
@@ -855,7 +855,7 @@ mod tests {
     fn recover_from() {
         let tx = Transaction {
             hash: H256::from_str(
-                "415bd4a9c915f7b0790b280ed26270234c7f9f191498f04bcad9e914fea9f8df",
+                "7e4823cfb836f84e8cef3040c69e23558a7434b01b9006759af26a5f9d53977c",
             )
             .unwrap(),
             nonce: 65.into(),

--- a/corebc-core/src/utils/anvil.rs
+++ b/corebc-core/src/utils/anvil.rs
@@ -11,6 +11,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+use super::NetworkType;
+
 /// How long we will wait for anvil to indicate that it is ready.
 const ANVIL_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 
@@ -225,9 +227,18 @@ impl Anvil {
         if let Some(mnemonic) = self.mnemonic {
             cmd.arg("-m").arg(mnemonic);
         }
+        let network: NetworkType;
 
         if let Some(chain_id) = self.chain_id {
             cmd.arg("--chain-id").arg(chain_id.to_string());
+
+            if chain_id == 1 {
+                network = NetworkType::Mainnet;
+            } else {
+                network = NetworkType::Testnet;
+            }
+        } else {
+            network = NetworkType::Testnet;
         }
 
         if let Some(block_time) = self.block_time {
@@ -276,7 +287,7 @@ impl Anvil {
                 let key_hex = hex::decode(key_str).expect("could not parse as hex");
                 let key = K256SecretKey::from_bytes(&GenericArray::clone_from_slice(&key_hex))
                     .expect("did not get private key");
-                addresses.push(secret_key_to_address(&SigningKey::from(&key)));
+                addresses.push(secret_key_to_address(&SigningKey::from(&key), &network));
                 private_keys.push(key);
             }
         }

--- a/corebc-core/src/utils/ganache.rs
+++ b/corebc-core/src/utils/ganache.rs
@@ -10,6 +10,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+use super::NetworkType;
+
 /// Default amount of time we will wait for ganache to indicate that it is ready.
 const GANACHE_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 
@@ -154,6 +156,7 @@ impl Ganache {
     /// If spawning the instance fails at any point.
     #[track_caller]
     pub fn spawn(self) -> GanacheInstance {
+        let network: NetworkType;
         let mut cmd = Command::new("ganache-cli");
         cmd.stdout(std::process::Stdio::piped());
         let port = if let Some(port) = self.port { port } else { unused_ports::<1>()[0] };
@@ -169,6 +172,9 @@ impl Ganache {
 
         if let Some(fork) = self.fork {
             cmd.arg("-f").arg(fork);
+            network = NetworkType::Mainnet;
+        } else {
+            network = NetworkType::Testnet;
         }
 
         cmd.args(self.args);
@@ -206,7 +212,7 @@ impl Ganache {
                 let key_hex = hex::decode(key_str).expect("could not parse as hex");
                 let key = K256SecretKey::from_bytes(&GenericArray::clone_from_slice(&key_hex))
                     .expect("did not get private key");
-                addresses.push(secret_key_to_address(&SigningKey::from(&key)));
+                addresses.push(secret_key_to_address(&SigningKey::from(&key), &network));
                 private_keys.push(key);
             }
         }

--- a/corebc-core/src/utils/mod.rs
+++ b/corebc-core/src/utils/mod.rs
@@ -24,7 +24,7 @@ pub use anvil::{Anvil, AnvilInstance};
 pub mod moonbeam;
 
 mod hash;
-pub use hash::{hash_message, id, keccak256, serialize};
+pub use hash::{hash_message, id, serialize, sha3};
 
 mod units;
 use serde::{Deserialize, Deserializer};
@@ -305,7 +305,7 @@ pub fn get_contract_address(
     stream.append(&sender.into());
     stream.append(&nonce.into());
 
-    let hash = keccak256(&stream.out());
+    let hash = sha3(&stream.out());
 
     let mut bytes = [0u8; 20];
     bytes.copy_from_slice(&hash[12..]);
@@ -324,7 +324,7 @@ pub fn get_create2_address(
     init_code: impl AsRef<[u8]>,
     network: NetworkType,
 ) -> Address {
-    let init_code_hash = keccak256(init_code.as_ref());
+    let init_code_hash = sha3(init_code.as_ref());
     get_create2_address_from_hash(from, salt, init_code_hash, network)
 }
 
@@ -344,7 +344,7 @@ pub fn get_create2_address_from_hash(
     bytes.extend_from_slice(salt);
     bytes.extend_from_slice(init_code_hash);
 
-    let hash = keccak256(bytes);
+    let hash = sha3(bytes);
 
     let mut bytes = [0u8; 20];
     bytes.copy_from_slice(&hash[12..]);
@@ -353,7 +353,7 @@ pub fn get_create2_address_from_hash(
     to_ican(&addr, &network)
 }
 
-fn to_ican(addr: &H160, network: &NetworkType) -> Address {
+pub fn to_ican(addr: &H160, network: &NetworkType) -> Address {
     let prefix = match network {
         NetworkType::Mainnet => MAINNET,
         NetworkType::Testnet => TESTNET,
@@ -412,16 +412,17 @@ fn construct_ican_address(prefix: &str, checksum: &u64, addr: &H160) -> Address 
 
 /// Converts a K256 SigningKey to an Ethereum Address
 /// CORETODO: FIX ASAP ICAN ADDRESSES
-pub fn secret_key_to_address(secret_key: &SigningKey) -> Address {
+pub fn secret_key_to_address(secret_key: &SigningKey, network: &NetworkType) -> Address {
     let public_key = secret_key.verifying_key();
     let public_key = public_key.to_encoded_point(/* compress = */ false);
     let public_key = public_key.as_bytes();
     debug_assert_eq!(public_key[0], 0x04);
-    let hash = keccak256(&public_key[1..]);
+    let hash = sha3(&public_key[1..]);
 
-    let mut bytes = [0u8; 22];
-    bytes.copy_from_slice(&hash[10..]);
-    Address::from(bytes)
+    let mut bytes = [0u8; 20];
+    bytes.copy_from_slice(&hash[12..]);
+    let addr = H160::from(bytes);
+    to_ican(&addr, &network)
 }
 
 /// Encodes an Ethereum address to its [EIP-55] checksum.
@@ -437,7 +438,7 @@ pub fn to_checksum(addr: &Address, chain_id: Option<u8>) -> String {
         Some(chain_id) => format!("{chain_id}0x{addr:x}"),
         None => format!("{addr:x}"),
     };
-    let hash = hex::encode(keccak256(prefixed_addr));
+    let hash = hex::encode(sha3(prefixed_addr));
     let hash = hash.as_bytes();
 
     let addr_hex = hex::encode(addr.as_bytes());
@@ -908,10 +909,10 @@ mod tests {
         // http://ethereum.stackexchange.com/questions/760/how-is-the-address-of-an-ethereum-contract-computed
         let from = "00006ac7ea33f8831ea9dcc53393aaa88b25a785dbf0".parse::<Address>().unwrap();
         for (nonce, expected) in [
-            "cb87710e394030001792b93c6ea71b4c2368bb8b4017",
-            "cb21a79824e457d4b330661df28c5fc1728c5fae314a",
-            "cb787ad0ea20cfe9c222244a4577c3d41b3b3b9dfce8",
-            "cb388c61b93eb63e44468716b75ce44f865f33c05d9e",
+            "cb7060435dcdcd1fde7fe4238204365e486a1c345e03",
+            "cb45936ded405892dc4f98cc5e04805d03c200c706a5",
+            "cb38a7d7c76ecab54e75a0d6a06faf3b441a304a9c64",
+            "cb64355702d8b1f36617d3554a5fad1187a74934d42d",
         ]
         .iter()
         .enumerate()
@@ -922,50 +923,49 @@ mod tests {
     }
 
     #[test]
-    // Test vectors from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1014.md#examples
     fn create2_address() {
         for (from, salt, init_code, expected) in &[
             (
                 "00000000000000000000000000000000000000000000",
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 "00",
-                "cb14cd8eda3eab4b22e34e95cd21d62c1c1ad54c9d8e",
+                "cb52a55032de3186cea55fdef3fdb0dbd45b18bba964",
             ),
             (
                 "0000deadbeef00000000000000000000000000000000",
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 "00",
-                "cb3365e5e5eb99a7419f6cd3aed1a6298b4752693bad",
+                "cb6480d15ddb300c9631bb03d106e8638a823701ecac",
             ),
             (
                 "0000deadbeef00000000000000000000000000000000",
                 "000000000000000000000000feed000000000000000000000000000000000000",
                 "00",
-                "cb50e323ba16a26d26e04808123d7c15dc6ca52f6b3b",
+                "cb875362c88b4f021806a12e94623c7a83e8c01473af",
             ),
             (
                 "00000000000000000000000000000000000000000000",
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 "deadbeef",
-                "cb71c8ac5b5a2956fb39dd44ed742d4e2f7175e6007f",
+                "cb40fce72bafe6e89f533630b9a876c1d56bfc0d7707",
             ),
             (
                 "000000000000000000000000000000000000deadbeef",
                 "00000000000000000000000000000000000000000000000000000000cafebabe",
                 "deadbeef",
-                "0xcb430cadfcaf9708b0ca1e7a92fd9914d9bff15b0af1",
+                "cb43d3c6aee116a1f8f82a0a4f2ea2a02059cafe6789",
             ),
             (
                 "000000000000000000000000000000000000deadbeef",
                 "00000000000000000000000000000000000000000000000000000000cafebabe",
                 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                "cb7256f1a67291016459e23309f3ad4b67692691b617",
+                "cb516997e86459f44af92ab7e927c54fe47fadcbbd6c",
             ),
             (
                 "00000000000000000000000000000000000000000000",
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 "",
-                "cb22ae7f1e229e37882ecdbc1a0069c5902c996f7a20",
+                "cb3680e5927ec9af1efc619ee6d4198e97c91ab72a96",
             ),
         ] {
             // get_create2_address()
@@ -976,7 +976,7 @@ mod tests {
             assert_eq!(expected, get_create2_address(from, salt.clone(), init_code.clone(), NetworkType::Mainnet));
 
             // get_create2_address_from_hash()
-            let init_code_hash = keccak256(init_code).to_vec();
+            let init_code_hash = sha3(init_code).to_vec();
             assert_eq!(expected, get_create2_address_from_hash(from, salt, init_code_hash, NetworkType::Mainnet))
         }
     }


### PR DESCRIPTION
This pr changes the hashing function from keccak256 to sha3.

Sorry for the weird commit history, the rebase didn't work as expected and now it's kind of a mess.

Thankfully this pr doesn't introduce many changes.

