### PR TITLE
Feature/network serde

### DIFF
--- a/corebc-core/Cargo.toml
+++ b/corebc-core/Cargo.toml
@@ -40,7 +40,7 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 # misc
 chrono = { version = "0.4", default-features = false }
 serde.workspace = true
-serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"]}
+serde_json = { workspace = true, features = ["arbitrary_precision"]}
 thiserror.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 hex.workspace = true

--- a/corebc-core/Cargo.toml
+++ b/corebc-core/Cargo.toml
@@ -40,7 +40,7 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 # misc
 chrono = { version = "0.4", default-features = false }
 serde.workspace = true
-serde_json = { workspace = true, features = ["arbitrary_precision"] }
+serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"]}
 thiserror.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 hex.workspace = true

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -21,8 +21,6 @@ impl std::fmt::Display for ParseNetworkError {
 
 /// An Ethereum EIP-155 Network.
 #[derive(
-    Deserialize,
-    Serialize,
     Clone,
     Copy,
     Debug,
@@ -195,6 +193,7 @@ impl<'de> Deserialize<'de> for Network {
 
 impl From<String> for Network {
     fn from(s: String) -> Network {
+        println!("s: {}", s);
         match s.as_str() {
             "mainnet" | "1" => Network::Mainnet,
             "devin" | "3" => Network::Devin,

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -199,6 +199,20 @@ impl<'de> Deserialize<'de> for Network {
                 formatter.write_str("network (mainnet, devin or private-<id>))")
             }
 
+            fn visit_i64<E>(self, value: i64) -> Result<Network, E>
+            where
+                E: de::Error,
+            {
+                println!("visit_i64: {}", value);
+                if value <= 0 {
+                    return Err(de::Error::invalid_value(
+                        de::Unexpected::Signed(value),
+                        &self,
+                    ));
+                }
+                Ok(Network::from(value as u64))
+            }
+
             fn visit_u64<E>(self, value: u64) -> Result<Network, E>
             where
                 E: de::Error,
@@ -206,6 +220,7 @@ impl<'de> Deserialize<'de> for Network {
                 println!("visit_u64: {}", value);
                 Ok(Network::from(value))
             }
+
 
             fn visit_str<E>(self, value: &str) -> Result<Network, E>
             where

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -2,7 +2,6 @@ use super::{U128, U256, U512, U64};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer
 };
-use serde_json::value::RawValue;
 use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
 use strum::{EnumCount, EnumIter, EnumVariantNames};
 
@@ -190,16 +189,18 @@ impl<'de> Deserialize<'de> for Network {
         D: Deserializer<'de>,
     {
         println!("{}", 111);
-        let s: Box<RawValue> = Deserialize::deserialize(deserializer)?;
+        let s: Box<String> = Deserialize::deserialize(deserializer)?;
+        println!("{}", 222);
+
         println!("{}", s);
 
-        let network:Result<String, serde_json::Error> = serde_json::from_str(s.clone().get()); 
+        let network:Result<String, serde_json::Error> = serde_json::from_str(s.as_str()); 
         if network.is_ok() {
             return Ok(Network::from(network.unwrap()))
         }
         println!("22222222 {}", s);
 
-        let network:Result<u64, serde_json::Error> = serde_json::from_str(s.get()); 
+        let network:Result<u64, serde_json::Error> = serde_json::from_str(s.as_str()); 
         if network.is_ok() {
             return Ok(Network::from(network.unwrap()))
         }

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -186,14 +186,19 @@ impl<'de> Deserialize<'de> for Network {
     where
         D: Deserializer<'de>,
     {
+        println!("33: {}", 3); 
+
         let s = String::deserialize(deserializer)?;
+
+        println!("s22: {}", s); 
+
         Ok(Network::from(s))
     }
 }
 
 impl From<String> for Network {
     fn from(s: String) -> Network {
-        println!("s: {}", s);
+        println!("s: {}", s); 
         match s.as_str() {
             "mainnet" | "1" => Network::Mainnet,
             "devin" | "3" => Network::Devin,

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -21,6 +21,8 @@ impl std::fmt::Display for ParseNetworkError {
 
 /// An Ethereum EIP-155 Network.
 #[derive(
+    Deserialize,
+    Serialize,
     Clone,
     Copy,
     Debug,

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -1,6 +1,6 @@
 use super::{U128, U256, U512, U64};
 use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer, Serialize, Serializer
 };
 use serde_json::value::RawValue;
 use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
@@ -189,6 +189,7 @@ impl<'de> Deserialize<'de> for Network {
     where
         D: Deserializer<'de>,
     {
+        println!("{}", 111);
         let s: Box<RawValue> = Deserialize::deserialize(deserializer)?;
         println!("{}", s);
 

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -190,11 +190,13 @@ impl<'de> Deserialize<'de> for Network {
         D: Deserializer<'de>,
     {
         let s: Box<RawValue> = Deserialize::deserialize(deserializer)?;
+        println!("{}", s);
 
         let network:Result<String, serde_json::Error> = serde_json::from_str(s.clone().get()); 
         if network.is_ok() {
             return Ok(Network::from(network.unwrap()))
         }
+        println!("22222222 {}", s);
 
         let network:Result<u64, serde_json::Error> = serde_json::from_str(s.get()); 
         if network.is_ok() {

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -1,9 +1,8 @@
 use super::{U128, U256, U512, U64};
 use serde::{
-    de::{Deserialize, Deserializer, self, Visitor},
+    de::{self, Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
-use serde_json::Deserializer as JsonDeserializer;
 use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
 use strum::{EnumCount, EnumIter, EnumVariantNames};
 
@@ -203,12 +202,8 @@ impl<'de> Deserialize<'de> for Network {
             where
                 E: de::Error,
             {
-                println!("visit_i64: {}", value);
                 if value <= 0 {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Signed(value),
-                        &self,
-                    ));
+                    return Err(de::Error::invalid_value(de::Unexpected::Signed(value), &self))
                 }
                 Ok(Network::from(value as u64))
             }
@@ -217,25 +212,14 @@ impl<'de> Deserialize<'de> for Network {
             where
                 E: de::Error,
             {
-                println!("visit_u64: {}", value);
                 Ok(Network::from(value))
             }
-
 
             fn visit_str<E>(self, value: &str) -> Result<Network, E>
             where
                 E: de::Error,
             {
-                println!("visit_str: {}", value);
                 Ok(Network::from(value.to_string()))
-            }
-
-            fn visit_string<E>(self, value: String) -> Result<Network, E>
-            where
-                E: de::Error,
-            {
-                println!("visit_string: {}", value);
-                Ok(Network::from(value))
             }
         }
 

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -1,5 +1,8 @@
 use super::{U128, U256, U512, U64};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use serde_json::value::RawValue;
 use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
 use strum::{EnumCount, EnumIter, EnumVariantNames};
 
@@ -186,14 +189,19 @@ impl<'de> Deserialize<'de> for Network {
     where
         D: Deserializer<'de>,
     {
-        println!("33: {}", 3); 
-        println!("3333: {}", deserializer); 
+        let s: Box<RawValue> = Deserialize::deserialize(deserializer)?;
 
-        let s = String::deserialize(deserializer)?;
+        let network:Result<String, serde_json::Error> = serde_json::from_str(s.clone().get()); 
+        if network.is_ok() {
+            return Ok(Network::from(network.unwrap()))
+        }
 
-        println!("s22: {}", s); 
+        let network:Result<u64, serde_json::Error> = serde_json::from_str(s.get()); 
+        if network.is_ok() {
+            return Ok(Network::from(network.unwrap()))
+        }
 
-        Ok(Network::from(s))
+        Err(serde::de::Error::custom("invalid network"))
     }
 }
 

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -203,6 +203,7 @@ impl<'de> Deserialize<'de> for Network {
             where
                 E: de::Error,
             {
+                println!("visit_u64: {}", value);
                 Ok(Network::from(value))
             }
 
@@ -210,6 +211,7 @@ impl<'de> Deserialize<'de> for Network {
             where
                 E: de::Error,
             {
+                println!("visit_str: {}", value);
                 Ok(Network::from(value.to_string()))
             }
 
@@ -217,6 +219,7 @@ impl<'de> Deserialize<'de> for Network {
             where
                 E: de::Error,
             {
+                println!("visit_string: {}", value);
                 Ok(Network::from(value))
             }
         }

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -26,6 +26,7 @@ impl std::fmt::Display for ParseNetworkError {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     PartialEq,
     Eq,
     PartialOrd,
@@ -183,34 +184,8 @@ impl Serialize for Network {
     }
 }
 
-impl<'de> Deserialize<'de> for Network {
-    fn deserialize<D>(deserializer: D) -> Result<Network, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        println!("{}", 111);
-        let s: Box<String> = Deserialize::deserialize(deserializer)?;
-        println!("{}", 222);
-
-        println!("{}", s);
-
-        if let Ok(network) = Network::try_from(s.as_str()) {
-            return Ok(network)
-        }
-        println!("22222222 {}", s);
-
-        let network:Result<u64, serde_json::Error> = serde_json::from_str(s.as_str()); 
-        if network.is_ok() {
-            return Ok(Network::from(network.unwrap()))
-        }
-
-        Err(serde::de::Error::custom("invalid network"))
-    }
-}
-
 impl From<String> for Network {
     fn from(s: String) -> Network {
-        println!("s: {}", s); 
         match s.as_str() {
             "mainnet" | "1" => Network::Mainnet,
             "devin" | "3" => Network::Devin,

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -187,6 +187,7 @@ impl<'de> Deserialize<'de> for Network {
         D: Deserializer<'de>,
     {
         println!("33: {}", 3); 
+        println!("3333: {}", deserializer); 
 
         let s = String::deserialize(deserializer)?;
 

--- a/corebc-core/src/types/network.rs
+++ b/corebc-core/src/types/network.rs
@@ -194,9 +194,8 @@ impl<'de> Deserialize<'de> for Network {
 
         println!("{}", s);
 
-        let network:Result<String, serde_json::Error> = serde_json::from_str(s.as_str()); 
-        if network.is_ok() {
-            return Ok(Network::from(network.unwrap()))
+        if let Ok(network) = Network::try_from(s.as_str()) {
+            return Ok(network)
         }
         println!("22222222 {}", s);
 

--- a/corebc-core/src/types/transaction/response.rs
+++ b/corebc-core/src/types/transaction/response.rs
@@ -294,7 +294,7 @@ mod tests {
     //         hash:
     // H256::from_str("929ff27a5c7833953df23103c4eb55ebdfb698678139d751c51932163877fada").unwrap(),
     //         input: Bytes::from(
-    //             
+    //
     // hex::decode("
     // a9059cbb000000000000000000000000fdae129ecc2c27d166a3131098bc05d143fa258e0000000000000000000000000000000000000000000000000000000002faf080"
     // ).unwrap()         ),
@@ -313,7 +313,7 @@ mod tests {
     //     assert_eq!(
     //         tx.rlp(),
     //         Bytes::from(
-    //             
+    //
     // hex::decode("
     // f8ac808512ec276caf83010e2b960000dac17f958d2ee523a2206206994597c13d831ec780b844a9059cbb000000000000000000000000fdae129ecc2c27d166a3131098bc05d143fa258e0000000000000000000000000000000000000000000000000000000002faf08025a0c81e70f9e49e0d3b854720143e86d172fecc9e76ef8a8666f2fdc017017c5141a01dd3410180f6a6ca3e25ad3058789cd0df3321ed76b5b4dbe0a2bb2dc28ae274"
     // ).unwrap()         )
@@ -331,7 +331,7 @@ mod tests {
     //         hash:
     // H256::from_str("929ff27a5c7833953df23103c4eb55ebdfb698678139d751c51932163877fada").unwrap(),
     //         input: Bytes::from(
-    //             
+    //
     // hex::decode("
     // a9059cbb000000000000000000000000fdae129ecc2c27d166a3131098bc05d143fa258e0000000000000000000000000000000000000000000000000000000002faf080"
     // ).unwrap()         ),
@@ -367,7 +367,7 @@ mod tests {
     //         .unwrap(),
     //         nonce: 65.into(),
     //         block_hash: Some(
-    //             
+    //
     // H256::from_str("f43869e67c02c57d1f9a07bb897b54bec1cfa1feb704d91a2ee087566de5df2c")
     //                 .unwrap(),
     //         ),

--- a/corebc-middleware/src/signer.rs
+++ b/corebc-middleware/src/signer.rs
@@ -358,7 +358,7 @@ mod tests {
     //     let tx: TypedTransaction = TransactionRequest {
     //         from: None,
     //         to: Some(
-    //             
+    //
     // "cb81a111da2c7ec8cee4baa791504379a6230fd1c7af".parse::<Address>().unwrap().into(),
     //         ),
     //         value: Some(1_000_000_000.into()),


### PR DESCRIPTION
In foundry configs we have to parse Network in 3 ways:
1) String "mainnet", "devin" or "private-{id}"
2) String with id of network - "1", "3" ...
3) Number as id of network - 1, 3 ....

This test https://github.com/bchainhub/foundry/blob/master/config/src/cache.rs#L255 now do not pass because we can only parse network from strings "1" or "mainnet". But if we use just u64 number it panics.

This PR adds support to deserealize network from u64 